### PR TITLE
Fix "unreadable content" error and compatibility mode in generated .docx

### DIFF
--- a/src/md-to-docx-ooxml.property.test.ts
+++ b/src/md-to-docx-ooxml.property.test.ts
@@ -160,9 +160,7 @@ describe('OOXML Generation Properties', () => {
         ...rows.map(row => ({ cells: row.map(c => [{ type: 'text' as const, text: c }]), header: false }))
       ];
       const token: MdToken = { type: 'table', runs: [], rows: tableRows };
-      const state = { commentId: 0, comments: [], relationships: new Map(), nextRId: 1, rIdOffset: 3, warnings: [], hasList: false, hasComments: false };
-      
-      const table = generateTable(token, state);
+      const table = generateTable(token);
       
       // Count rows (header + data)
       const rowMatches = table.match(/<w:tr>/g);

--- a/src/md-to-docx.test.ts
+++ b/src/md-to-docx.test.ts
@@ -238,16 +238,6 @@ describe('generateParagraph', () => {
 });
 
 describe('generateTable', () => {
-  const createState = () => ({
-    commentId: 0,
-    comments: [],
-    relationships: new Map(),
-    nextRId: 1, rIdOffset: 3,
-    warnings: [],
-    hasList: false,
-    hasComments: false
-  });
-
   it('generates basic table', () => {
     const rows: MdTableRow[] = [
       {
@@ -272,8 +262,7 @@ describe('generateTable', () => {
       rows
     };
     
-    const state = createState();
-    const result = generateTable(token, state);
+    const result = generateTable(token);
     
     expect(result).toContain('<w:tbl>');
     expect(result).toContain('<w:tblBorders>');
@@ -302,8 +291,7 @@ describe('generateTable', () => {
       rows
     };
     
-    const state = createState();
-    const result = generateTable(token, state);
+    const result = generateTable(token);
     
     expect(result).toContain('<w:b/>');
   });
@@ -324,8 +312,7 @@ describe('generateTable', () => {
       rows
     };
     
-    const state = createState();
-    const result = generateTable(token, state);
+    const result = generateTable(token);
     
     // Should only have one <w:b/> tag
     const boldMatches = result.match(/<w:b\/>/g);
@@ -468,7 +455,7 @@ console.log('code');
 describe('CriticMarkup OOXML generation', () => {
   const createState = () => ({
     commentId: 0,
-    comments: [],
+    comments: [] as { id: number; author: string; date: string; text: string }[],
     relationships: new Map(),
     nextRId: 1, rIdOffset: 3,
     warnings: [],

--- a/src/md-to-docx.ts
+++ b/src/md-to-docx.ts
@@ -1139,7 +1139,7 @@ export function generateParagraph(token: MdToken, state: DocxGenState, options?:
   return '<w:p>' + pPr + runs + '</w:p>';
 }
 
-export function generateTable(token: MdToken, state: DocxGenState): string {
+export function generateTable(token: MdToken): string {
   if (!token.rows) return '';
   
   let xml = '<w:tbl>';
@@ -1184,7 +1184,7 @@ export function generateDocumentXml(tokens: MdToken[], state: DocxGenState, opti
   
   for (const token of tokens) {
     if (token.type === 'table') {
-      body += generateTable(token, state);
+      body += generateTable(token);
     } else {
       body += generateParagraph(token, state, options, bibEntries);
     }


### PR DESCRIPTION
The document.xml declared mc:Ignorable="w14 wp14" but never declared the
xmlns:wp14 namespace, causing Word to reject the file as unreadable. Also,
settings.xml was only included when a template provided one, defaulting Word
to compatibilityMode=12 (Word 2007) which triggers compatibility mode and
"save as newer format" prompts.

- Add missing xmlns:wp14 and xmlns:w15 namespace declarations to document.xml
- Always generate settings.xml with compatibilityMode=15 (Word 2013+/365)
- Add fontTable.xml with Calibri, Times New Roman, Courier New declarations
- Add docProps/core.xml and docProps/app.xml for proper document properties
- Update [Content_Types].xml, _rels/.rels, and document.xml.rels accordingly

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated DOCX files now always include document settings, font tables, and core/app metadata, improving compatibility with Word and preserving creation/app info.
  * Table generation updated for more consistent output, reducing issues with table rendering in exported documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->