### PR TITLE
Simplify annotations menu: remove Highlight, rename Comment

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,11 +59,7 @@
         "title": "Highlight"
       },
       {
-        "command": "manuscript-markdown.insertComment",
-        "title": "Comment"
-      },
-      {
-        "command": "manuscript-markdown.highlightAndComment",
+        "command": "manuscript-markdown.comment",
         "title": "Comment"
       },
       {
@@ -284,7 +280,7 @@
       ],
       "markdown.annotations": [
         {
-          "command": "manuscript-markdown.highlightAndComment",
+          "command": "manuscript-markdown.comment",
           "when": "editorLangId == markdown",
           "group": "1_manuscript-markdown@1"
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,11 +47,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('manuscript-markdown.highlight', () => 
 			applyFormatting((text) => formatting.wrapSelection(text, '{==', '==}'))
 		),
-		vscode.commands.registerCommand('manuscript-markdown.insertComment', () => {
-			const authorName = author.getFormattedAuthorName();
-			applyFormatting((text) => formatting.wrapSelection(text, '{>>', '<<}', 3, authorName));
-		}),
-		vscode.commands.registerCommand('manuscript-markdown.highlightAndComment', () => {
+		vscode.commands.registerCommand('manuscript-markdown.comment', () => {
 			const authorName = author.getFormattedAuthorName();
 			applyFormatting((text) => formatting.highlightAndComment(text, authorName));
 		}),


### PR DESCRIPTION
## Summary
- Removed standalone "Highlight" from the annotations submenu
- Renamed "Comment and highlight" to "Comment"

With these changes, CriticMarkup highlight notation (`{== ==}`) is used solely to mark what text a comment is associated with, simplifying the annotations UX.

Closes #23
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new comment options for specific editing operations: substitute, addition, and deletion formatting.

* **Bug Fixes**
  * Streamlined comment functionality by consolidating multiple comment-related commands.

* **Chores**
  * Removed the standalone "Comment and highlight" option; highlight functionality is now integrated into individual comment commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->