### PR TITLE
Preserve author name in docx↔md round trip

### DIFF
--- a/docs/converter.md
+++ b/docs/converter.md
@@ -5,6 +5,7 @@ The DOCX converter transforms Microsoft Word documents into Manuscript Markdown 
 ## What's Preserved
 
 - **Title**: Word `Title` paragraph style extracted to `title:` frontmatter (multiple title paragraphs become multiple entries)
+- **Author**: `dc:creator` from Document Properties extracted to `author:` frontmatter (only if non-blank)
 - **Text formatting**: bold, italic, underline, strikethrough, superscript, subscript
 - **Headings**: H1 through H6 from Word heading styles
 - **Lists**: bulleted and numbered lists with nesting
@@ -70,6 +71,7 @@ note-type: in-text
 | Field | Description |
 |-------|-------------|
 | `title` | Document title. Multiple `title:` entries create multi-paragraph titles. |
+| `author` | Document author. Written as `dc:creator` in Document Properties on export. |
 | `csl` | CSL style short name (e.g., `apa`, `chicago-author-date`, `bmj`) or absolute path to a `.csl` file |
 | `locale` | Optional locale override (e.g., `en-US`, `en-GB`). Defaults to the style's own locale. |
 | `note-type` | Optional Zotero note type: `in-text` (default), `footnotes`, or `endnotes`. Legacy numeric values (0, 1, 2) are still accepted. |
@@ -85,6 +87,7 @@ If a style is not bundled, you will be prompted to download it from the [CSL sty
 ### What's Exported
 
 - **Title**: `title:` frontmatter entries rendered as Word Title-styled paragraphs at the beginning of the document
+- **Author**: `author:` frontmatter written as `dc:creator` in Document Properties (omitted if no author specified)
 - **Text formatting**: bold, italic, underline, strikethrough, superscript, subscript, highlights (including colored)
 - **Headings**: H1 through H6 with proper Word heading styles
 - **Lists**: bulleted and numbered lists with nesting

--- a/src/author-metadata.test.ts
+++ b/src/author-metadata.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'bun:test';
+import JSZip from 'jszip';
+import { parseFrontmatter, serializeFrontmatter } from './frontmatter';
+import { extractAuthor, convertDocx } from './converter';
+import { convertMdToDocx } from './md-to-docx';
+
+// --- Frontmatter parsing ---
+
+describe('parseFrontmatter with author', () => {
+  it('parses author field', () => {
+    const md = '---\nauthor: Jane Doe\n---\n\nBody.';
+    const { metadata } = parseFrontmatter(md);
+    expect(metadata.author).toBe('Jane Doe');
+  });
+
+  it('parses author alongside other fields', () => {
+    const md = '---\ntitle: My Title\nauthor: Jane Doe\ncsl: apa\n---\n\nBody.';
+    const { metadata } = parseFrontmatter(md);
+    expect(metadata.title).toEqual(['My Title']);
+    expect(metadata.author).toBe('Jane Doe');
+    expect(metadata.csl).toBe('apa');
+  });
+
+  it('ignores blank author', () => {
+    const md = '---\nauthor: \n---\n\nBody.';
+    const { metadata } = parseFrontmatter(md);
+    expect(metadata.author).toBeUndefined();
+  });
+
+  it('strips quotes from author', () => {
+    const md = '---\nauthor: "Jane Doe"\n---\n\nBody.';
+    const { metadata } = parseFrontmatter(md);
+    expect(metadata.author).toBe('Jane Doe');
+  });
+
+  it('returns no author when absent', () => {
+    const md = '---\ncsl: apa\n---\n\nBody.';
+    const { metadata } = parseFrontmatter(md);
+    expect(metadata.author).toBeUndefined();
+  });
+});
+
+// --- Frontmatter serialization ---
+
+describe('serializeFrontmatter with author', () => {
+  it('serializes author', () => {
+    const result = serializeFrontmatter({ author: 'Jane Doe' });
+    expect(result).toBe('---\nauthor: Jane Doe\n---\n');
+  });
+
+  it('places author after title and before csl', () => {
+    const result = serializeFrontmatter({ title: ['My Title'], author: 'Jane Doe', csl: 'apa' });
+    expect(result).toBe('---\ntitle: My Title\nauthor: Jane Doe\ncsl: apa\n---\n');
+  });
+
+  it('omits author when undefined', () => {
+    const result = serializeFrontmatter({ csl: 'apa' });
+    expect(result).not.toContain('author');
+  });
+});
+
+// --- extractAuthor from DOCX ---
+
+describe('extractAuthor', () => {
+  it('extracts dc:creator from core.xml', async () => {
+    const zip = new JSZip();
+    zip.file('docProps/core.xml',
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+      '<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/">' +
+      '<dc:creator>Jane Doe</dc:creator>' +
+      '</cp:coreProperties>');
+    const author = await extractAuthor(zip);
+    expect(author).toBe('Jane Doe');
+  });
+
+  it('returns undefined when dc:creator is missing', async () => {
+    const zip = new JSZip();
+    zip.file('docProps/core.xml',
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+      '<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/">' +
+      '</cp:coreProperties>');
+    const author = await extractAuthor(zip);
+    expect(author).toBeUndefined();
+  });
+
+  it('returns undefined when dc:creator is blank', async () => {
+    const zip = new JSZip();
+    zip.file('docProps/core.xml',
+      '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' +
+      '<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/">' +
+      '<dc:creator>   </dc:creator>' +
+      '</cp:coreProperties>');
+    const author = await extractAuthor(zip);
+    expect(author).toBeUndefined();
+  });
+
+  it('returns undefined when core.xml is absent', async () => {
+    const zip = new JSZip();
+    const author = await extractAuthor(zip);
+    expect(author).toBeUndefined();
+  });
+});
+
+// --- md→docx round-trip ---
+
+describe('author md→docx→md round-trip', () => {
+  it('preserves author through round-trip', async () => {
+    const md = '---\ntitle: Test\nauthor: Jane Doe\n---\n\nHello world.';
+    const docxResult = await convertMdToDocx(md);
+    const mdResult = await convertDocx(docxResult.docx);
+    const { metadata } = parseFrontmatter(mdResult.markdown);
+    expect(metadata.author).toBe('Jane Doe');
+  });
+
+  it('omits dc:creator when no author in frontmatter', async () => {
+    const md = '---\ntitle: Test\n---\n\nHello world.';
+    const docxResult = await convertMdToDocx(md);
+
+    // Verify the generated docx has no dc:creator
+    const zip = await JSZip.loadAsync(docxResult.docx);
+    const coreXml = await zip.file('docProps/core.xml')!.async('string');
+    expect(coreXml).not.toContain('dc:creator');
+  });
+
+  it('XML-escapes author with special characters', async () => {
+    const md = '---\nauthor: O\'Brien & Sons <Ltd>\n---\n\nBody.';
+    const docxResult = await convertMdToDocx(md);
+    const zip = await JSZip.loadAsync(docxResult.docx);
+    const coreXml = await zip.file('docProps/core.xml')!.async('string');
+    expect(coreXml).toContain('<dc:creator>');
+    expect(coreXml).not.toContain('& Sons');  // should be &amp;
+    expect(coreXml).toContain('&amp; Sons');
+    expect(coreXml).toContain('&lt;Ltd&gt;');
+  });
+});

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -27,6 +27,7 @@ export function noteTypeToNumber(nt: NoteType): number {
 
 export interface Frontmatter {
   title?: string[];
+  author?: string;
   csl?: string;
   locale?: string;
   noteType?: NoteType;
@@ -62,6 +63,9 @@ export function parseFrontmatter(markdown: string): { metadata: Frontmatter; bod
         if (!metadata.title) metadata.title = [];
         metadata.title.push(value);
         break;
+      case 'author':
+        if (value) metadata.author = value;
+        break;
       case 'csl':
         metadata.csl = value;
         break;
@@ -90,6 +94,7 @@ export function serializeFrontmatter(metadata: Frontmatter): string {
       lines.push(`title: ${t}`);
     }
   }
+  if (metadata.author) lines.push(`author: ${metadata.author}`);
   if (metadata.csl) lines.push(`csl: ${metadata.csl}`);
   if (metadata.locale) lines.push(`locale: ${metadata.locale}`);
   if (metadata.noteType) lines.push(`note-type: ${metadata.noteType}`);

--- a/src/md-to-docx.ts
+++ b/src/md-to-docx.ts
@@ -982,14 +982,17 @@ function fontTableXml(): string {
     '</w:fonts>';
 }
 
-function corePropsXml(): string {
+function corePropsXml(author?: string): string {
   const now = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
-  return '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
-    '<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n' +
-    '<dc:creator>Manuscript Markup</dc:creator>\n' +
-    '<dcterms:created xsi:type="dcterms:W3CDTF">' + now + '</dcterms:created>\n' +
+  let xml = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n' +
+    '<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n';
+  if (author && author.trim()) {
+    xml += '<dc:creator>' + escapeXml(author) + '</dc:creator>\n';
+  }
+  xml += '<dcterms:created xsi:type="dcterms:W3CDTF">' + now + '</dcterms:created>\n' +
     '<dcterms:modified xsi:type="dcterms:W3CDTF">' + now + '</dcterms:modified>\n' +
     '</cp:coreProperties>';
+  return xml;
 }
 
 function appPropsXml(): string {
@@ -1417,7 +1420,7 @@ export async function convertMdToDocx(
   }
 
   // Document properties
-  zip.file('docProps/core.xml', corePropsXml());
+  zip.file('docProps/core.xml', corePropsXml(frontmatter.author));
   zip.file('docProps/app.xml', appPropsXml());
 
   // Write Zotero document preferences if CSL style specified


### PR DESCRIPTION
## Summary

- Extracts `dc:creator` from DOCX Document Properties into `author:` YAML frontmatter on import (only if non-blank)
- Writes `author:` frontmatter back as `dc:creator` on export, with proper XML escaping; omits the element entirely when no author is specified
- Documents the behavior in `docs/converter.md`

Closes #3

## Test plan

- [x] 15 new tests in `src/author-metadata.test.ts` covering:
  - Frontmatter parsing (normal, blank, quoted, absent, alongside other fields)
  - Frontmatter serialization (normal, field ordering, omission)
  - `extractAuthor` from DOCX (normal, missing element, blank, missing file)
  - Full md→docx→md round-trip with and without author
  - XML escaping of special characters (`&`, `<`, `>`)
- [x] All 592 existing tests continue to pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/26" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Author metadata is now supported during document conversion—extracted from source files and preserved in frontmatter during round-trip conversions.

* **Documentation**
  * Updated documentation to reflect author metadata mapping and handling across conversion workflows.

* **Tests**
  * Added comprehensive test coverage for author metadata extraction, parsing, serialization, and round-trip preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->