### PR TITLE
Add semantic header row markup to DOCX table export

### DIFF
--- a/src/md-to-docx.test.ts
+++ b/src/md-to-docx.test.ts
@@ -381,16 +381,49 @@ describe('generateTable', () => {
         ]
       }
     ];
-    
+
     const token: MdToken = {
       type: 'table',
       runs: [],
       rows
     };
-    
+
     const result = generateTable(token, makeState());
-    
+
     expect(result).toContain('<w:b/>');
+  });
+
+  it('emits tblLook firstRow when table has header rows', () => {
+    const rows: MdTableRow[] = [
+      { header: true, cells: [{ runs: [{ type: 'text', text: 'H' }] }] },
+      { header: false, cells: [{ runs: [{ type: 'text', text: 'D' }] }] }
+    ];
+    const token: MdToken = { type: 'table', runs: [], rows };
+    const result = generateTable(token, makeState());
+    expect(result).toContain('<w:tblLook w:firstRow="1"/>');
+  });
+
+  it('does not emit tblLook firstRow when no header rows', () => {
+    const rows: MdTableRow[] = [
+      { header: false, cells: [{ runs: [{ type: 'text', text: 'D' }] }] }
+    ];
+    const token: MdToken = { type: 'table', runs: [], rows };
+    const result = generateTable(token, makeState());
+    expect(result).not.toContain('<w:tblLook');
+  });
+
+  it('emits tblHeader on header rows', () => {
+    const rows: MdTableRow[] = [
+      { header: true, cells: [{ runs: [{ type: 'text', text: 'H' }] }] },
+      { header: false, cells: [{ runs: [{ type: 'text', text: 'D' }] }] }
+    ];
+    const token: MdToken = { type: 'table', runs: [], rows };
+    const result = generateTable(token, makeState());
+    // Header row should have tblHeader
+    expect(result).toContain('<w:trPr><w:tblHeader/></w:trPr>');
+    // Only one tblHeader (not on the data row)
+    const matches = result.match(/<w:tblHeader\/>/g);
+    expect(matches?.length).toBe(1);
   });
 
   it('preserves existing bold formatting in header cells', () => {

--- a/src/md-to-docx.ts
+++ b/src/md-to-docx.ts
@@ -1368,8 +1368,10 @@ export function generateTable(token: MdToken, state: DocxGenState, options?: MdT
     row.cells.some(cell => (cell.colspan && cell.colspan > 1) || (cell.rowspan && cell.rowspan > 1))
   );
 
+  const hasHeaderRow = token.rows.some(row => row.header);
+
   let xml = '<w:tbl>';
-  xml += '<w:tblPr><w:tblBorders><w:top w:val="single" w:sz="4" w:space="0" w:color="auto"/><w:left w:val="single" w:sz="4" w:space="0" w:color="auto"/><w:bottom w:val="single" w:sz="4" w:space="0" w:color="auto"/><w:right w:val="single" w:sz="4" w:space="0" w:color="auto"/><w:insideH w:val="single" w:sz="4" w:space="0" w:color="auto"/><w:insideV w:val="single" w:sz="4" w:space="0" w:color="auto"/></w:tblBorders><w:tblCellMar><w:top w:w="0" w:type="dxa"/><w:left w:w="108" w:type="dxa"/><w:bottom w:w="0" w:type="dxa"/><w:right w:w="108" w:type="dxa"/></w:tblCellMar><w:tblW w:w="0" w:type="auto"/></w:tblPr>';
+  xml += '<w:tblPr><w:tblBorders><w:top w:val="single" w:sz="4" w:space="0" w:color="auto"/><w:left w:val="single" w:sz="4" w:space="0" w:color="auto"/><w:bottom w:val="single" w:sz="4" w:space="0" w:color="auto"/><w:right w:val="single" w:sz="4" w:space="0" w:color="auto"/><w:insideH w:val="single" w:sz="4" w:space="0" w:color="auto"/><w:insideV w:val="single" w:sz="4" w:space="0" w:color="auto"/></w:tblBorders><w:tblCellMar><w:top w:w="0" w:type="dxa"/><w:left w:w="108" w:type="dxa"/><w:bottom w:w="0" w:type="dxa"/><w:right w:w="108" w:type="dxa"/></w:tblCellMar><w:tblW w:w="0" w:type="auto"/>' + (hasHeaderRow ? '<w:tblLook w:firstRow="1"/>' : '') + '</w:tblPr>';
 
   // Emit tblGrid if spans are present
   if (hasSpans) {
@@ -1385,6 +1387,9 @@ export function generateTable(token: MdToken, state: DocxGenState, options?: MdT
 
   for (const row of token.rows) {
     xml += '<w:tr>';
+    if (row.header) {
+      xml += '<w:trPr><w:tblHeader/></w:trPr>';
+    }
     let cellIdx = 0;
     let gridCol = 0;
 


### PR DESCRIPTION
## Summary

- Emit `<w:tblLook w:firstRow="1"/>` inside `<w:tblPr>` when any row has `header: true`, so Word recognizes the table has a distinct header row
- Emit `<w:trPr><w:tblHeader/></w:trPr>` on each header `<w:tr>`, so Word repeats header rows across page breaks
- Fixes MD→DOCX→MD roundtrip: header rows now survive the trip as `<th>` instead of being demoted to `<td>`

Closes #45

## Test plan

- [x] New test: `tblLook firstRow` emitted when header rows present
- [x] New test: `tblLook` not emitted when no header rows
- [x] New test: `tblHeader` emitted only on header rows
- [x] Existing header bold tests still pass
- [x] Full test suite passes (689 tests)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
