### PR TITLE
Move Custom Extensions link out of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ manuscript-markdown paper.md      # Markdown → DOCX
 
 - [Specification Overview](docs/specification.md)
 - [CriticMarkup Syntax](docs/criticmarkup.md)
-- [Custom Extensions](docs/custom-extensions.md)
 - [DOCX Converter](docs/converter.md)
 - [Zotero Citation Roundtrip](docs/zotero-roundtrip.md)
 - [CLI Tool](docs/cli.md)


### PR DESCRIPTION
## Summary
- Removes the "Custom Extensions" link from the README Documentation section to avoid confusion with "VS Code extension" references elsewhere in the README
- Custom extensions are already documented in and linked from the [Specification Overview](docs/specification.md)

Closes #57
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed a documentation reference link from the project resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->