### PR TITLE
Add configuration settings documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ manuscript-markdown paper.md      # Markdown → DOCX
 - [Custom Extensions](docs/custom-extensions.md)
 - [DOCX Converter](docs/converter.md)
 - [Zotero Citation Roundtrip](docs/zotero-roundtrip.md)
+- [Configuration](docs/configuration.md)
 - [CLI Tool](docs/cli.md)
 - [Development Guide](docs/development.md)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,37 @@
+# Configuration
+
+All settings are under the `manuscriptMarkdown` namespace in VS Code settings.
+
+## Comment Attribution
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `includeAuthorNameInComments` | boolean | `true` | Include author name in comment attribution |
+| `authorName` | string | `""` | Author name to use in comments (leave empty to use OS username) |
+| `includeTimestampInComments` | boolean | `true` | Include timestamp in comment attribution (format: `yyyy-mm-dd hh:mm`) |
+
+## Highlights
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `defaultHighlightColor` | string | `"yellow"` | Default background color for `==highlight==` formatting when no color is specified. Options: `yellow`, `green`, `turquoise`, `pink`, `blue`, `red`, `dark-blue`, `teal`, `violet`, `dark-red`, `dark-yellow`, `gray-50`, `gray-25`, `black` |
+
+## Citations
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `citationKeyFormat` | string | `"authorYearTitle"` | Citation key format for DOCX to Markdown conversion. `authorYearTitle` (e.g., smith2020effects), `authorYear` (e.g., smith2020), or `numeric` (e.g., 1, 2, 3) |
+| `mixedCitationStyle` | string | `"separate"` | How to render mixed Zotero/non-Zotero grouped citations. `separate`: each portion gets its own parentheses (clean Zotero refresh). `unified`: one set of parentheses wrapping everything (looks like one group but may desync on Zotero refresh) |
+
+## Citekey Language Server
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `enableCitekeyLanguageServer` | boolean | `true` | Enable citekey language server features: `@` completions, go-to-definition, and find references for citation keys |
+| `citekeyReferencesFromMarkdown` | boolean | `false` | Include markdown usages in Find All References when invoked from a markdown file. Off by default because VS Code's built-in Markdown Language Features already reports these; enabling this may produce duplicate entries |
+
+## DOCX Conversion
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `tableIndent` | integer | `2` | Number of spaces per indent level for HTML tables in DOCX to Markdown conversion |


### PR DESCRIPTION
## Summary
- Adds `docs/configuration.md` documenting all VS Code extension settings organized by category (comment attribution, highlights, citations, citekey language server, DOCX conversion)
- Links the new doc from the README Documentation section

Closes #58
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
