### PR TITLE
Add LSP hover for non-inline comments and rename language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ manuscript-markdown paper.md      # Markdown → DOCX
 
 - [Specification Overview](docs/specification.md)
 - [CriticMarkup Syntax](docs/criticmarkup.md)
-- [Citekey Language Server](docs/citekey-language-server.md)
+- [Language Server](docs/language-server.md)
 - [DOCX Converter](docs/converter.md)
 - [Zotero Citation Roundtrip](docs/zotero-roundtrip.md)
 - [Configuration](docs/configuration.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,11 +23,11 @@ All settings are under the `manuscriptMarkdown` namespace in VS Code settings.
 | `citationKeyFormat` | string | `"authorYearTitle"` | Citation key format for DOCX to Markdown conversion. `authorYearTitle` (e.g., smith2020effects), `authorYear` (e.g., smith2020), or `numeric` (e.g., 1, 2, 3) |
 | `mixedCitationStyle` | string | `"separate"` | How to render mixed Zotero/non-Zotero grouped citations. `separate`: each portion gets its own parentheses (clean Zotero refresh). `unified`: one set of parentheses wrapping everything (looks like one group but may desync on Zotero refresh) |
 
-## Citekey Language Server
+## Language Server
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `enableCitekeyLanguageServer` | boolean | `true` | Enable citekey language server features: `@` completions, go-to-definition, and find references for citation keys |
+| `enableCitekeyLanguageServer` | boolean | `true` | Enable language server features: `@` completions, go-to-definition, find references for citation keys, and comment hover |
 | `citekeyReferencesFromMarkdown` | boolean | `false` | Include markdown usages in Find All References when invoked from a markdown file. Off by default because VS Code's built-in Markdown Language Features already reports these; enabling this may produce duplicate entries |
 
 ## DOCX Conversion

--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -1,6 +1,6 @@
-# Citekey Language Server
+# Language Server
 
-The citekey language server provides IDE features for pandoc-style citations (`[@citekey]`) in markdown files paired with `.bib` files.
+The language server provides IDE features for pandoc-style citations (`[@citekey]`) in markdown files paired with `.bib` files, and hover information for non-inline comments.
 
 ## Capabilities
 
@@ -20,6 +20,10 @@ From a `[@citekey]` in markdown, navigates to the key's declaration in the `.bib
 - **From markdown**: returns the `.bib` declaration location. Markdown-to-markdown references are provided by VS Code's built-in Markdown Language Features extension.
 - **From `.bib`**: finds all `[@citekey]` usages across paired markdown files.
 
+### Comment Hover
+
+When hovering over a non-inline comment body (`{#id>>...<<}`), the server displays the associated text — the content between the matching `{#id}` and `{/id}` range markers. CriticMarkup tags are stripped from the displayed text, and the result is rendered as Markdown.
+
 ## Bib file pairing
 
 The LSP resolves which `.bib` file a markdown document is paired with using two mechanisms, in order:
@@ -37,5 +41,5 @@ No workspace directory tree scanning is performed.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `manuscriptMarkdown.enableCitekeyLanguageServer` | boolean | `true` | Enable/disable all citekey language server features |
+| `manuscriptMarkdown.enableCitekeyLanguageServer` | boolean | `true` | Enable/disable all language server features |
 | `manuscriptMarkdown.citekeyReferencesFromMarkdown` | boolean | `false` | Include markdown usages in Find All References when invoked from a markdown file. Off by default because VS Code's built-in Markdown Language Features already reports these |

--- a/package.json
+++ b/package.json
@@ -593,7 +593,7 @@
         "manuscriptMarkdown.enableCitekeyLanguageServer": {
           "type": "boolean",
           "default": true,
-          "description": "Enable citekey language server features: @ completions, go-to-definition, and find references for citation keys."
+          "description": "Enable language server features: @ completions, go-to-definition, find references for citation keys, and comment hover."
         },
         "manuscriptMarkdown.defaultHighlightColor": {
           "type": "string",

--- a/src/lsp/comment-language.test.ts
+++ b/src/lsp/comment-language.test.ts
@@ -1,0 +1,154 @@
+import { describe, test, expect } from 'bun:test';
+import {
+	findCommentIdAtOffset,
+	findRangeTextForId,
+	stripCriticMarkup,
+} from './comment-language';
+
+describe('findCommentIdAtOffset', () => {
+	test('returns id when cursor is inside a comment body', () => {
+		const text = 'Some text\n\n{#1>>alice: note<<}';
+		// Offset pointing to 'a' in 'alice'
+		const bodyStart = text.indexOf('{#1>>');
+		expect(findCommentIdAtOffset(text, bodyStart + 5)).toBe('1');
+	});
+
+	test('returns id when cursor is on the opening delimiter', () => {
+		const text = '{#abc>>comment<<}';
+		expect(findCommentIdAtOffset(text, 0)).toBe('abc');
+	});
+
+	test('returns id when cursor is just before the closing delimiter', () => {
+		const text = '{#abc>>comment<<}';
+		// Last char before closing: 't' at index 13
+		expect(findCommentIdAtOffset(text, 13)).toBe('abc');
+	});
+
+	test('returns undefined when cursor is past the closing delimiter', () => {
+		const text = '{#abc>>comment<<} after';
+		expect(findCommentIdAtOffset(text, 17)).toBeUndefined();
+	});
+
+	test('returns undefined when cursor is outside any comment body', () => {
+		const text = 'no comments here';
+		expect(findCommentIdAtOffset(text, 5)).toBeUndefined();
+	});
+
+	test('returns undefined when cursor is on a range marker, not a body', () => {
+		const text = '{#1}text{/1}';
+		expect(findCommentIdAtOffset(text, 0)).toBeUndefined();
+	});
+
+	test('handles multiple comment bodies with different IDs', () => {
+		const text = '{#1>>first<<}\n{#2>>second<<}';
+		const idx1 = text.indexOf('{#1>>');
+		const idx2 = text.indexOf('{#2>>');
+		expect(findCommentIdAtOffset(text, idx1 + 5)).toBe('1');
+		expect(findCommentIdAtOffset(text, idx2 + 5)).toBe('2');
+	});
+
+	test('handles non-numeric IDs', () => {
+		const text = '{#intro-note>>some comment<<}';
+		expect(findCommentIdAtOffset(text, 15)).toBe('intro-note');
+	});
+});
+
+describe('findRangeTextForId', () => {
+	test('returns text between matching start and end markers', () => {
+		const text = '{#1}hello world{/1}';
+		expect(findRangeTextForId(text, '1')).toBe('hello world');
+	});
+
+	test('returns undefined when no start marker exists', () => {
+		const text = 'no markers here';
+		expect(findRangeTextForId(text, '1')).toBeUndefined();
+	});
+
+	test('returns undefined when no end marker exists', () => {
+		const text = '{#1}text without end';
+		expect(findRangeTextForId(text, '1')).toBeUndefined();
+	});
+
+	test('returns text containing CriticMarkup (not stripped)', () => {
+		const text = '{#1}{==highlighted==}{>>comment<<}{/1}';
+		expect(findRangeTextForId(text, '1')).toBe('{==highlighted==}{>>comment<<}');
+	});
+
+	test('handles multi-line range text', () => {
+		const text = '{#1}line one\nline two\nline three{/1}';
+		expect(findRangeTextForId(text, '1')).toBe('line one\nline two\nline three');
+	});
+
+	test('returns correct range when multiple IDs exist', () => {
+		const text = '{#1}first{/1} and {#2}second{/2}';
+		expect(findRangeTextForId(text, '1')).toBe('first');
+		expect(findRangeTextForId(text, '2')).toBe('second');
+	});
+
+	test('handles non-numeric IDs', () => {
+		const text = '{#my-note}some text{/my-note}';
+		expect(findRangeTextForId(text, 'my-note')).toBe('some text');
+	});
+
+	test('handles nested ranges', () => {
+		const text = '{#outer}text {#inner}more text{/inner}{/outer}';
+		expect(findRangeTextForId(text, 'outer')).toBe('text {#inner}more text{/inner}');
+		expect(findRangeTextForId(text, 'inner')).toBe('more text');
+	});
+});
+
+describe('stripCriticMarkup', () => {
+	test('strips {==...==} keeping content', () => {
+		expect(stripCriticMarkup('{==highlighted==}')).toBe('highlighted');
+	});
+
+	test('strips {>>...<<} removing content', () => {
+		expect(stripCriticMarkup('{>>comment<<}')).toBe('');
+	});
+
+	test('strips {#id>>...<<} removing content', () => {
+		expect(stripCriticMarkup('{#1>>alice: note<<}')).toBe('');
+	});
+
+	test('strips {#id} and {/id} markers', () => {
+		expect(stripCriticMarkup('{#1}text{/1}')).toBe('text');
+	});
+
+	test('strips {++...++} keeping content', () => {
+		expect(stripCriticMarkup('{++added++}')).toBe('added');
+	});
+
+	test('strips {--...--} keeping content', () => {
+		expect(stripCriticMarkup('{--deleted--}')).toBe('deleted');
+	});
+
+	test('strips {~~...~~} keeping content', () => {
+		expect(stripCriticMarkup('{~~old~>new~~}')).toBe('old~>new');
+	});
+
+	test('handles combined inline comment with highlight', () => {
+		expect(stripCriticMarkup('{==highlighted text==}{>>alice: comment<<}')).toBe('highlighted text');
+	});
+
+	test('handles text with no markup', () => {
+		expect(stripCriticMarkup('plain text')).toBe('plain text');
+	});
+
+	test('handles empty string', () => {
+		expect(stripCriticMarkup('')).toBe('');
+	});
+
+	test('strips nested ID ranges', () => {
+		const input = '{#outer}text {#inner}more{/inner} end{/outer}';
+		expect(stripCriticMarkup(input)).toBe('text more end');
+	});
+
+	test('strips multiple markup types in one text', () => {
+		const input = '{==bold==} and {++added++} and {--removed--} and {>>comment<<}';
+		expect(stripCriticMarkup(input)).toBe('bold and added and removed and');
+	});
+
+	test('trims whitespace', () => {
+		expect(stripCriticMarkup('  hello  ')).toBe('hello');
+	});
+});

--- a/src/lsp/comment-language.ts
+++ b/src/lsp/comment-language.ts
@@ -1,0 +1,58 @@
+const ID_COMMENT_BODY_RE = /\{#([a-zA-Z0-9_-]+)>>([\s\S]*?)<<\}/g;
+
+/**
+ * If `offset` falls inside a `{#id>>...<<}` comment body, return the id.
+ */
+export function findCommentIdAtOffset(text: string, offset: number): string | undefined {
+	const re = new RegExp(ID_COMMENT_BODY_RE.source, 'g');
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(text)) !== null) {
+		if (offset >= m.index && offset < m.index + m[0].length) {
+			return m[1];
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Find the text between `{#id}` and `{/id}` range markers for the given id.
+ */
+export function findRangeTextForId(text: string, id: string): string | undefined {
+	// IDs are [a-zA-Z0-9_-]+ so no special regex escaping needed
+	const startRe = new RegExp(`\\{#${id}\\}`, 'g');
+	const endRe = new RegExp(`\\{/${id}\\}`, 'g');
+
+	const startMatch = startRe.exec(text);
+	if (!startMatch) return undefined;
+
+	const contentStart = startMatch.index + startMatch[0].length;
+	endRe.lastIndex = contentStart;
+	const endMatch = endRe.exec(text);
+	if (!endMatch) return undefined;
+
+	return text.slice(contentStart, endMatch.index);
+}
+
+/**
+ * Strip all CriticMarkup tags from text.
+ * Comment bodies are removed entirely; other delimiters are unwrapped (content kept).
+ */
+export function stripCriticMarkup(text: string): string {
+	let result = text;
+	// Remove ID-based comment bodies (content removed)
+	result = result.replace(/\{#[a-zA-Z0-9_-]+>>([\s\S]*?)<<\}/g, '');
+	// Remove inline comment bodies (content removed)
+	result = result.replace(/\{>>([\s\S]*?)<<\}/g, '');
+	// Remove ID range markers
+	result = result.replace(/\{#[a-zA-Z0-9_-]+\}/g, '');
+	result = result.replace(/\{\/[a-zA-Z0-9_-]+\}/g, '');
+	// Unwrap highlight delimiters (keep content)
+	result = result.replace(/\{==([\s\S]*?)==\}/g, '$1');
+	// Unwrap addition delimiters (keep content)
+	result = result.replace(/\{\+\+([\s\S]*?)\+\+\}/g, '$1');
+	// Unwrap deletion delimiters (keep content)
+	result = result.replace(/\{--([\s\S]*?)--\}/g, '$1');
+	// Unwrap substitution (keep content)
+	result = result.replace(/\{~~([\s\S]*?)~~\}/g, '$1');
+	return result.trim();
+}


### PR DESCRIPTION
Show associated text when hovering over non-inline comment bodies
({#id>>...<<}), with CriticMarkup tags stripped and markdown rendered.
Rename "Citekey Language Server" to "Language Server" across docs and code.

Closes #69

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
