### PR TITLE
Fix title case in Annotations menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,15 +64,15 @@
       },
       {
         "command": "manuscript-markdown.substituteAndComment",
-        "title": "Comment and substitution"
+        "title": "Comment and Substitution"
       },
       {
         "command": "manuscript-markdown.additionAndComment",
-        "title": "Comment and mark as addition"
+        "title": "Comment and Mark as Addition"
       },
       {
         "command": "manuscript-markdown.deletionAndComment",
-        "title": "Comment and mark as deletion"
+        "title": "Comment and Mark as Deletion"
       },
       {
         "command": "manuscript-markdown.formatBold",


### PR DESCRIPTION
## Summary
- Fix inconsistent capitalization in three Annotations menu command titles to use Title Case, matching all other commands

## Test plan
- [x] `bun test` — all 790 tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated VS Code command titles to use consistent title case formatting for substitute, addition, and deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->