### PR TITLE
Add 'Open in Word' explorer context menu for .docx files

### DIFF
--- a/package.json
+++ b/package.json
@@ -562,7 +562,7 @@
         {
           "command": "manuscript-markdown.convertDocx",
           "when": "resourceExtname == .docx",
-          "group": "9_export"
+          "group": "9_export@0"
         },
         {
           "command": "manuscript-markdown.openInWord",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -237,10 +237,22 @@ export function activate(context: vscode.ExtensionContext) {
 	// Register Open in Word command
 	context.subscriptions.push(
 		vscode.commands.registerCommand('manuscript-markdown.openInWord', async (uri?: vscode.Uri) => {
-			if (!uri) { return; }
-			const opened = await vscode.env.openExternal(uri);
-			if (!opened) {
-				vscode.window.showErrorMessage('Failed to open file in external application.');
+			try {
+				if (!uri) {
+					const files = await vscode.window.showOpenDialog({
+						filters: { 'Word Documents': ['docx'] },
+						canSelectMany: false,
+					});
+					if (!files || files.length === 0) { return; }
+					uri = files[0];
+				}
+				const opened = await vscode.env.openExternal(uri);
+				if (!opened) {
+					vscode.window.showErrorMessage('Failed to open file in external application.');
+				}
+			} catch (err: unknown) {
+				const message = err instanceof Error ? err.message : String(err);
+				vscode.window.showErrorMessage(`Failed to open file: ${message}`);
 			}
 		})
 	);


### PR DESCRIPTION
## Summary
- Adds an **Open in Word** right-click menu item for `.docx` files in the Explorer pane
- Uses `vscode.env.openExternal` to open in the OS default `.docx` handler
- Hidden on remote/SSH/dev container workspaces via the `!remoteName` when-clause

## Test plan
- [ ] Right-click a `.docx` file in a local workspace — both "Export to Markdown" and "Open in Word" appear, with "Open in Word" below
- [ ] Click "Open in Word" — file opens in the system default `.docx` handler
- [ ] Right-click a `.md` file — "Open in Word" does **not** appear
- [ ] Open via Remote-SSH or dev container — "Open in Word" does **not** appear for `.docx` files
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Open in Word" functionality for .docx files, allowing you to open documents directly in your Word application from the editor.
  * Introduced a new Word Document action menu for .docx files with additional document management options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->