### PR TITLE
Add guard tests for code review follow-up items

### DIFF
--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -354,10 +354,12 @@ describe('Syntax grammar invariants', () => {
     const grammar = JSON.parse(fs.readFileSync(grammarPath, 'utf-8'));
 
     const commentRule = grammar?.repository?.comment;
+    expect(commentRule).toBeDefined();
     expect(commentRule.name).toMatch(/^meta\.comment/);
     expect(commentRule.contentName).toMatch(/^meta\.comment/);
 
     const commentWithIdRule = grammar?.repository?.comment_with_id;
+    expect(commentWithIdRule).toBeDefined();
     expect(commentWithIdRule.contentName).toMatch(/^meta\.comment/);
   });
 });


### PR DESCRIPTION
## Summary

Addresses four items raised in an external code review on PR #81. After investigation, no behavioral changes are needed, but two guard tests close coverage gaps.

## Review items disposition

1. **`while` vs `end` coexistence** — Added guard test. No rules currently have both keys, but `while` silently overrides `end` in vscode-textmate, so a future contributor could introduce a subtle bug. The new test iterates all repository rules and fails if both keys coexist.

2. **`surroundingPairs` for multi-character delimiters** — **No change.** VS Code's surround-selection lookup is keyed by the single typed open character (`{`), so the built-in Markdown `{`→`}` pair fires before any multi-character `{>>` pair is considered. Adding these entries would silently do nothing. If wrap-selection UX is desired, it should be explicit editor commands (out of scope).

3. **`meta.comment` vs `comment.block` scopes** — **No change.** `meta.comment*` is intentional (documented in `AGENTS.md:75`) to avoid suppressing VS Code editor features. Added guard test to prevent regression.

4. **Tokenization-based grammar testing** — **No change this PR.** Structural tests miss regex correctness and rule priority, but for a 13-rule grammar the risk is low. A pilot tokenization test layer is a good future improvement tracked separately.

## Test plan

- [x] `bun test` — all 945 tests pass including the two new guard tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests to ensure grammar syntax rules behave as expected, including validation checks to prevent conflicting rules from coexisting and confirmation that comment scope naming adheres to established conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->