### PR TITLE
Add "Open in Word" button to export success message

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -968,14 +968,16 @@ async function exportMdToDocx(context: vscode.ExtensionContext, uri?: vscode.Uri
 
 	await vscode.workspace.fs.writeFile(docxUri, result.docx);
 
-	if (result.warnings.length > 0) {
-		vscode.window.showWarningMessage('Export completed with warnings: ' + result.warnings.join('; '));
-	}
 	const filename = docxUri.fsPath.split(/[/\\]/).pop()!;
-	const action = await vscode.window.showInformationMessage(
-		`Exported to "${filename}"`,
-		'Open in Word'
-	);
+	const action = result.warnings.length > 0
+		? await vscode.window.showWarningMessage(
+			`Exported to "${filename}" with warnings: ${result.warnings.join('; ')}`,
+			'Open in Word'
+		)
+		: await vscode.window.showInformationMessage(
+			`Exported to "${filename}"`,
+			'Open in Word'
+		);
 	if (action === 'Open in Word') {
 		try {
 			const opened = await vscode.env.openExternal(docxUri);


### PR DESCRIPTION
## Summary
- Quotes the filename in the export success message so multi-word names read clearly (e.g. `Exported to "My Manuscript.docx"`)
- Adds an "Open in Word" action button that opens the exported `.docx` via `vscode.env.openExternal`

## Test plan
- [ ] Open a `.md` file and run "Export to Word"
- [ ] Confirm the message shows the quoted filename and an "Open in Word" button
- [ ] Click the button and verify the `.docx` opens in Word
- [ ] Dismiss without clicking and verify no side effects
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/89" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Export notifications now display the filename and provide an "Open in Word" action button
  * Users can now directly open exported DOCX files in their default application
  * Enhanced error handling with user feedback when file opening fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->