### PR TITLE
Ignore trailing semicolons in citation groups

### DIFF
--- a/src/md-to-docx.test.ts
+++ b/src/md-to-docx.test.ts
@@ -1319,6 +1319,13 @@ describe('Full MD→DOCX footnote generation', () => {
     expect(warnings.some(w => w.includes('[^1]') && w.includes('no matching reference'))).toBe(true);
   });
 
+  it('ignores trailing semicolon in citation group', async () => {
+    const bib = `@article{smith2020,\n  author = {Smith, John},\n  title = {Title},\n  year = {2020},\n}`;
+    const md = 'Text [@smith2020;].';
+    const { warnings } = await convertMdToDocx(md, { bibtex: bib });
+    expect(warnings).toEqual([]);
+  });
+
   it('stores MANUSCRIPT_FOOTNOTE_IDS for named labels', async () => {
     const md = 'Text[^my-note] here.\n\n[^my-note]: Named note.';
     const { docx } = await convertMdToDocx(md);

--- a/src/md-to-docx.ts
+++ b/src/md-to-docx.ts
@@ -343,7 +343,7 @@ function citationRule(state: any, silent: boolean): boolean {
     const keys: string[] = [];
     const locators = new Map<string, string>();
     
-    const parts = content.split(';').map((p: string) => p.trim().replace(/^@/, ''));
+    const parts = content.split(';').map((p: string) => p.trim().replace(/^@/, '')).filter(Boolean);
     for (const part of parts) {
       const commaPos = part.indexOf(',');
       if (commaPos !== -1) {


### PR DESCRIPTION
## Summary
- A citation like `[@key;]` (trailing semicolon) caused the parser to look up an empty string as a citation key, producing a spurious "Citation key not found:" warning
- Filter out empty keys after splitting on semicolons in the citation parser

## Test plan
- Added test: trailing semicolon in `[@smith2020;]` produces no warnings
- All existing citation and md-to-docx tests pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed citation parsing to properly ignore trailing semicolons and empty entries in citation groups, preventing warnings during document conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->