### PR TITLE
Auto-reuse existing DOCX styles in CLI, add --no-template flag

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,7 +51,8 @@ Produces `paper.docx`. Automatically loads `paper.bib` if present.
 | `--force` | both | Overwrite existing output files | `false` |
 | `--citation-key-format <fmt>` | DOCX→MD | Citation key format: `authorYearTitle`, `authorYear`, `numeric` | `authorYearTitle` |
 | `--bib <path>` | MD→DOCX | BibTeX file path | auto-detect |
-| `--template <path>` | MD→DOCX | Template DOCX for styling | none |
+| `--template <path>` | MD→DOCX | Template DOCX for styling | auto-reuse existing `.docx` |
+| `--no-template` | MD→DOCX | Disable auto-reuse of existing DOCX styles | `false` |
 | `--author <name>` | MD→DOCX | Author name | OS username |
 | `--mixed-citation-style <style>` | MD→DOCX | Mixed citation style: `separate`, `unified` | `separate` |
 | `--blockquote-style <style>` | MD→DOCX | Blockquote paragraph style: `Quote`, `IntenseQuote` | `Quote` |

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -130,6 +130,16 @@ test('parseArgs throws on invalid --table-indent', () => {
     .toThrow('Invalid table indent "abc". Use a non-negative integer');
 });
 
+test('parseArgs defaults noTemplate to false', () => {
+  const result = parseArgs(['node', 'cli.js', 'test.md']);
+  expect(result.noTemplate).toBe(false);
+});
+
+test('parseArgs parses --no-template', () => {
+  const result = parseArgs(['node', 'cli.js', 'test.md', '--no-template']);
+  expect(result.noTemplate).toBe(true);
+});
+
 test('parseArgs throws on invalid mixed citation style', () => {
   expect(() => parseArgs(['node', 'cli.js', 'test.md', '--mixed-citation-style', 'invalid']))
     .toThrow('Invalid mixed citation style "invalid". Use separate or unified');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -934,11 +934,13 @@ async function exportMdToDocx(context: vscode.ExtensionContext, uri?: vscode.Uri
 	}
 
 	// Auto-use existing .docx as style template when no explicit template is provided
+	let usedAutoTemplate = false;
 	if (!templateDocx) {
 		const existingDocxUri = vscode.Uri.file(input.basePath + '.docx');
 		if (await fileExists(existingDocxUri)) {
 			const data = await vscode.workspace.fs.readFile(existingDocxUri);
 			templateDocx = new Uint8Array(data);
+			usedAutoTemplate = true;
 		}
 	}
 
@@ -975,13 +977,16 @@ async function exportMdToDocx(context: vscode.ExtensionContext, uri?: vscode.Uri
 	await vscode.workspace.fs.writeFile(docxUri, result.docx);
 
 	const filename = docxUri.fsPath.split(/[/\\]/).pop()!;
+	const templateNote = usedAutoTemplate
+		? ' Styles from the existing .docx were preserved; delete it and re-export to start fresh.'
+		: '';
 	const action = result.warnings.length > 0
 		? await vscode.window.showWarningMessage(
-			`Exported to "${filename}" with warnings: ${result.warnings.join('; ')}`,
+			`Exported to "${filename}" with warnings: ${result.warnings.join('; ')}${templateNote}`,
 			'Open in Word'
 		)
 		: await vscode.window.showInformationMessage(
-			`Exported to "${filename}"`,
+			`Exported to "${filename}".${templateNote}`,
 			'Open in Word'
 		);
 	if (action === 'Open in Word') {


### PR DESCRIPTION
## Summary
- **CLI auto-template**: The CLI now auto-reuses an existing `.docx` at the output path as a style template when converting MD→DOCX, matching the VS Code extension behavior. No need to manually pass `--template paper.docx` on re-exports.
- **`--no-template` flag**: Added to opt out of auto-template when a clean export with default styles is desired.
- **VS Code notification**: The export success popup now informs users when styles from an existing `.docx` were preserved, with guidance to delete and re-export to start fresh.

Addresses review feedback from PR #92 regarding CLI/extension parity and silent auto-template behavior.

## Test plan
- [x] Existing CLI parser tests pass (985 tests, 0 failures)
- [x] New tests for `--no-template` parsing (default false, flag sets true)
- [ ] Manual: run `manuscript-markdown paper.md --force` when `paper.docx` exists — styles should be preserved
- [ ] Manual: run `manuscript-markdown paper.md --force --no-template` — should produce default styles
- [ ] Manual: VS Code "Export to Word" when `.docx` exists — popup should mention preserved styles
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
