### PR TITLE
Fix doc references, remove unused highlight command, link ui.md from …

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ manuscript-markdown paper.md      # Markdown → DOCX
 - [DOCX Converter](docs/converter.md)
 - [Zotero Citation Roundtrip](docs/zotero-roundtrip.md)
 - [Configuration](docs/configuration.md)
+- [User Interface](docs/ui.md)
 - [CLI Tool](docs/cli.md)
 - [Development Guide](docs/development.md)
 

--- a/docs/converter.md
+++ b/docs/converter.md
@@ -56,7 +56,7 @@ The converter also supports exporting Markdown back to DOCX, completing the roun
 
 1. Open a Markdown file in VS Code
 2. Click the **Export to Word** submenu in the editor title bar
-3. Choose **Export to Word** for default styling, or **Export to Word (with template)** to use a template DOCX for fonts, sizes, and spacing
+3. Choose **Export to Word** for default styling, or **Export to Word with Template** to use a template DOCX for fonts, sizes, and spacing
 
 If a companion `.bib` file exists with the same base name, it is automatically loaded for citation resolution. You can also specify a custom bibliography path in the YAML frontmatter using the `bibliography` field (see [Specification](specification.md#bibtex-companion-file)).
 
@@ -106,7 +106,7 @@ All [round-trip features](#round-trip-features) are preserved on export. The fol
 
 ### Template Support
 
-When using **Export to Word (with template)**, the converter extracts styling parts from the template:
+When using **Export to Word with Template**, the converter extracts styling parts from the template:
 
 - `word/styles.xml` — heading fonts, body text formatting, spacing
 - `word/theme/theme1.xml` — theme colors and fonts

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -95,8 +95,6 @@ Annotation and change-tracking commands — the Markdown equivalent of tracked c
 | Navigation | **Previous Change** | `manuscript-markdown.prevChange` |
 | | **Next Change** | `manuscript-markdown.nextChange` |
 
-> The extension also registers a **Highlight** command (`manuscript-markdown.highlight`) that wraps text in annotation highlight syntax (`{== ==}`). It does not appear in any menu but is available from the Command Palette.
-
 ---
 
 ### Export to Word
@@ -246,7 +244,7 @@ When the export finishes, a notification appears in the bottom-right corner with
 
 ### Export to Word with Template
 
-Behaves the same as [Export to Word](#export-to-word-md-docx), but first shows a file-picker dialog to choose a `.docx` template file. "Choosing a template" means selecting an existing `.docx` file whose paragraph formatting styles — fonts, sizes, spacing, colors — will be applied to the exported document.
+Behaves the same as [Export to Word](#export-to-word-md--docx), but first shows a file-picker dialog to choose a `.docx` template file. "Choosing a template" means selecting an existing `.docx` file whose paragraph formatting styles — fonts, sizes, spacing, colors — will be applied to the exported document.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -55,10 +55,6 @@
         "title": "Substitution"
       },
       {
-        "command": "manuscript-markdown.highlight",
-        "title": "Highlight"
-      },
-      {
         "command": "manuscript-markdown.comment",
         "title": "Comment"
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,9 +136,6 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('manuscript-markdown.markSubstitution', () => 
 			applyFormatting((text) => formatting.wrapSelection(text, '{~~', '~>~~}', text.length + 5))
 		),
-		vscode.commands.registerCommand('manuscript-markdown.highlight', () => 
-			applyFormatting((text) => formatting.wrapSelection(text, '{==', '==}'))
-		),
 		vscode.commands.registerCommand('manuscript-markdown.comment', () => {
 			const authorName = author.getFormattedAuthorName();
 			const useIds = vscode.workspace.getConfiguration('manuscriptMarkdown').get<boolean>('alwaysUseCommentIds', false);


### PR DESCRIPTION
…README

- Update "Export to Word (with template)" references in converter.md to match renamed menu item title
- Fix broken anchor link in ui.md (#export-to-word-md--docx)
- Remove unused manuscript-markdown.highlight command (redundant with formatHighlight)
- Add ui.md to README documentation list
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
