### PR TITLE
Fix duplicate Cancel button in file replace dialogs

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -289,11 +289,10 @@ export function activate(context: vscode.ExtensionContext) {
 						getOutputConflictMessage(basePath, conflictScenario),
 						{ modal: true },
 						'Replace',
-						'New Name',
-						'Cancel'
+						'New Name'
 					);
 
-					if (!choice || choice === 'Cancel') {
+					if (!choice) {
 						return;
 					}
 
@@ -904,11 +903,10 @@ async function resolveDocxOutputUri(basePath: string): Promise<vscode.Uri | unde
 		'\"' + name + '.docx\" already exists. Replace it or save with a new name?',
 		{ modal: true },
 		'Replace',
-		'New Name',
-		'Cancel'
+		'New Name'
 	);
 
-	if (!choice || choice === 'Cancel') {
+	if (!choice) {
 		return undefined;
 	}
 


### PR DESCRIPTION
## Summary
- VS Code modal dialogs automatically include a Cancel button, so passing `'Cancel'` as an explicit button option was creating a duplicate Cancel button
- Removed the explicit `'Cancel'` button from both the markdown/bib and docx file conflict dialogs
- The modal's built-in Cancel returns `undefined`, which is already handled by the `!choice` check

## Test plan
- [ ] Open a file that will trigger the "already exists" conflict dialog (md/bib or docx)
- [ ] Verify only one Cancel button appears alongside "New Name" and "Replace"
- [ ] Verify clicking Cancel (or pressing Escape) still cancels the operation
- [ ] Verify "Replace" and "New Name" still work as expected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined file overwrite confirmation dialogs for DOCX and Markdown exports by removing the "Cancel" option. Users now see only "Replace" and "New Name" choices. Cancellation behavior is now handled consistently across these workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->