### PR TITLE
fix ginormous vsix in ci

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -48,5 +48,8 @@ full_draft_temp/**
 *_temp/**
 .tmp/**
 
+# Native binaries (built separately, not needed in extension package)
+bin/**
+
 # Dependencies are bundled by esbuild into out/; exclude raw node_modules
 node_modules/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,7 +8,8 @@ tests/**
 out/**/*.test.js
 out/test-*.js
 out/__mocks__/**
-.*.bun-build
+**/.*.bun-build
+*.bun-build
 dist/**
 
 # Git and editor metadata
@@ -38,9 +39,13 @@ docs/**
 *.vsix
 *.docx
 sample.png
+sample.bib
+sample.md
+.DS_Store
 example.qmd
 bun.lock
 esbuild.mjs
+eslint.config.mjs
 setup.sh
 scripts/**
 revised_temp/**

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -9,6 +9,7 @@ const shared = {
   target: 'node20',
   format: 'cjs',
   sourcemap: true,
+  minify: true,
   outdir: 'out',
   // Keep __dirname/__filename as runtime values (esbuild default for
   // platform:'node'), which csl-loader.ts relies on to find bundled


### PR DESCRIPTION
- **Exclude bin/ from .vsix to fix bloated 434MB package**
- **Exclude more junk from .vsix and minify JS bundles**

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jbearak/manuscript-markdown/pull/212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
